### PR TITLE
Fixes the issue of handling NaN/None by using pandas Series in an optimized way.

### DIFF
--- a/django_pandas/utils.py
+++ b/django_pandas/utils.py
@@ -37,7 +37,7 @@ def replace_pk(model):
         pk_series = pk_series.where(pk_series.notnull(), None)
         cache_keys = pk_series.apply(
             get_cache_key_from_pk, convert_dtype=False)
-        unique_cache_keys = filter(None, cache_keys.unique())
+        unique_cache_keys = list(filter(None, cache_keys.unique()))
 
         if not unique_cache_keys:
             return pk_series
@@ -47,7 +47,7 @@ def replace_pk(model):
         if len(out_dict) < len(unique_cache_keys):
             out_dict = {base_cache_key % obj.pk: force_text(obj)
                         for obj in model.objects.filter(
-                            pk__in=filter(None, pk_series.unique()))}
+                            pk__in=list(filter(None, pk_series.unique())))}
             cache.set_many(out_dict)
 
         return list(map(out_dict.get, cache_keys))


### PR DESCRIPTION
This fixes an issue I was struggling with: sometimes the pk list is a series of floats (when there are NaN values), and sometimes it's just a series of int.  If it's a series of int, checking whether a pk is NaN raises a TypeError.

After digging, I figured that would be easier to use pandas Series to handle all this.  I made a lot of timeits to find the fastest algorithm I could do without having to use Cython.
It shouldn't be faster however, just as fast as before (when it was buggy).
