### PR TITLE
Make it compatible with python < 2.7 + bugfix in utils

### DIFF
--- a/django_pandas/utils.py
+++ b/django_pandas/utils.py
@@ -11,7 +11,7 @@ def replace_from_choices(choices):
 
 
 def get_base_cache_key(model):
-    return 'pandas_%s_%s_%%d_rendering' % (
+    return 'pandas_%s_%s_%%s_rendering' % (
         model._meta.app_label, model._meta.module_name)
 
 


### PR DESCRIPTION
Init of dictionnaries won't work with python version < 2.7. There are still some people forced to work with 2.6 out there :) 
And a quick fix to handle non integer primary keys
