### PR TITLE
Handle ManyToMany and OneToMany relations

### DIFF
--- a/django_pandas/io.py
+++ b/django_pandas/io.py
@@ -7,11 +7,20 @@ def to_fields(qs, fieldnames):
     for fieldname in fieldnames:
         model = qs.model
         for fieldname_part in fieldname.split('__'):
-            field = model._meta.get_field(fieldname_part)
-            if field.one_to_many:
-                model = field.related_model
-            elif field.get_internal_type() in ('ForeignKey', 'OneToOneField', 'ManyToManyField'):
-                model = field.rel.to
+            try:
+                field = model._meta.get_field(fieldname_part)
+            except django.db.models.fields.FieldDoesNotExist:
+                rels = model._meta.get_all_related_objects_with_model()
+                for relobj, _ in rels:
+                    if relobj.get_accessor_name() == fieldname_part:
+                        field = relobj.field
+                        model = field.model
+                        break
+            else:
+                if hasattr(field, "one_to_many") and field.one_to_many:
+                    model = field.related_model
+                elif field.get_internal_type() in ('ForeignKey', 'OneToOneField', 'ManyToManyField'):
+                    model = field.rel.to
         yield field
 
 

--- a/django_pandas/io.py
+++ b/django_pandas/io.py
@@ -8,7 +8,9 @@ def to_fields(qs, fieldnames):
         model = qs.model
         for fieldname_part in fieldname.split('__'):
             field = model._meta.get_field(fieldname_part)
-            if field.get_internal_type() in ('ForeignKey', 'OneToOneField'):
+            if field.one_to_many:
+                model = field.related_model
+            elif field.get_internal_type() in ('ForeignKey', 'OneToOneField', 'ManyToManyField'):
                 model = field.rel.to
         yield field
 

--- a/django_pandas/tests/models.py
+++ b/django_pandas/tests/models.py
@@ -150,3 +150,11 @@ class TradeLog(models.Model):
             self.volume,
             self.note
         )
+
+@python_2_unicode_compatible
+class Portfolio(models.Model):
+    name = models.CharField(max_length=20)
+    securities = models.ManyToManyField(Security)
+
+    def __str__(self):
+        return self.name

--- a/django_pandas/tests/test_io.py
+++ b/django_pandas/tests/test_io.py
@@ -153,7 +153,7 @@ class RelatedFieldsTest(TestCase):
     def test_many_to_many(self):
         qs = Portfolio.objects.all()
         cols = ['name', 'securities__symbol', 'securities__tradelog__log_datetime']
-        df = read_frame(qs, cols, verbose=False)
+        df = read_frame(qs, cols, verbose=True)
 
         denormalized = Portfolio.objects.all().values_list(*cols)
         self.assertEqual(df.shape, (len(denormalized), len(cols)))

--- a/django_pandas/tests/test_io.py
+++ b/django_pandas/tests/test_io.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from django.db.models import Sum
 import pandas as pd
 import numpy as np
-from .models import MyModel, Trader, Security, TradeLog, TradeLogNote, MyModelChoice
+from .models import MyModel, Trader, Security, TradeLog, TradeLogNote, MyModelChoice, Portfolio
 from django_pandas.io import read_frame
 
 
@@ -115,6 +115,11 @@ class RelatedFieldsTest(TestCase):
                                 log_datetime='2013-01-01T11:00:00',
                                 price=30, volume=300,
                                 note=TradeLogNote.objects.create(note='aah'))
+        value = Portfolio.objects.create(name="Fund 1")
+        value.securities.add(abc)
+        value.securities.add(zyz)
+        growth = Portfolio.objects.create(name="Fund 2")
+        growth.securities.add(abc)
 
     def test_verbose(self):
         qs = TradeLog.objects.all()
@@ -144,3 +149,16 @@ class RelatedFieldsTest(TestCase):
             list(qs.values_list('trader__name', flat=True)),
             df.trader__name.tolist()
         )
+
+    def test_many_to_many(self):
+        qs = Portfolio.objects.all()
+        cols = ['name', 'securities__symbol', 'securities__tradelog__log_datetime']
+        df = read_frame(qs, cols, verbose=False)
+
+        denormalized = Portfolio.objects.all().values_list(*cols)
+        self.assertEqual(df.shape, (len(denormalized), len(cols)))
+        for idx, row in enumerate(denormalized):
+            self.assertListEqual(
+                df.iloc[idx].tolist(),
+                list(row)
+            )


### PR DESCRIPTION
Similar to #43 but also allows OneToMany relations. Should address #40 as well.

One thing I noticed, though: does the `model` variable need to be assigned in `to_fields()` at all? We're only yielding `field`. Tests passed without setting `model` so I'm happy to go that route instead.