### PR TITLE
Fix Django 1.9 compatibility

### DIFF
--- a/django_pandas/io.py
+++ b/django_pandas/io.py
@@ -64,7 +64,7 @@ def read_frame(qs, fieldnames=(), index_col=None, coerce_float=False,
             fieldnames = tuple(fieldnames) + (index_col,)
 
         fields = to_fields(qs, fieldnames)
-    elif isinstance(qs, django.db.models.query.ValuesQuerySet):
+    elif isinstance(qs, django.db.models.query.ValuesIterable):
         if django.VERSION < (1, 8):
             annotation_field_names = qs.aggregate_names
         else:
@@ -78,7 +78,7 @@ def read_frame(qs, fieldnames=(), index_col=None, coerce_float=False,
         fields = qs.model._meta.fields
         fieldnames = [f.name for f in fields]
 
-    if isinstance(qs, django.db.models.query.ValuesQuerySet):
+    if isinstance(qs, django.db.models.query.ValuesIterable):
         recs = list(qs)
     else:
         recs = list(qs.values_list(*fieldnames))

--- a/django_pandas/io.py
+++ b/django_pandas/io.py
@@ -3,7 +3,6 @@ from .utils import update_with_verbose
 import django
 
 
-
 def to_fields(qs, fieldnames):
     for fieldname in fieldnames:
         model = qs.model

--- a/django_pandas/io.py
+++ b/django_pandas/io.py
@@ -3,6 +3,7 @@ from .utils import update_with_verbose
 import django
 
 
+
 def to_fields(qs, fieldnames):
     for fieldname in fieldnames:
         model = qs.model
@@ -57,14 +58,19 @@ def read_frame(qs, fieldnames=(), index_col=None, coerce_float=False,
                 The human readable version of the foreign key field is
                 defined in the ``__unicode__`` or ``__str__``
                 methods of the related class definition
-   """
+    """
+    if django.VERSION < (1, 9):
+        _ValuesList = django.db.models.query.ValuesQuerySet
+    else:
+        _ValuesList = django.db.models.query.ValuesIterable
+
     if fieldnames:
         if index_col is not None and index_col not in fieldnames:
             # Add it to the field names if not already there
             fieldnames = tuple(fieldnames) + (index_col,)
 
         fields = to_fields(qs, fieldnames)
-    elif isinstance(qs, django.db.models.query.ValuesIterable):
+    elif isinstance(qs, _ValuesList):
         if django.VERSION < (1, 8):
             annotation_field_names = qs.aggregate_names
         else:
@@ -78,7 +84,7 @@ def read_frame(qs, fieldnames=(), index_col=None, coerce_float=False,
         fields = qs.model._meta.fields
         fieldnames = [f.name for f in fields]
 
-    if isinstance(qs, django.db.models.query.ValuesIterable):
+    if isinstance(qs, _ValuesList):
         recs = list(qs)
     else:
         recs = list(qs.values_list(*fieldnames))

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'Django>=1.4.2',
-        'django-model-utils>=1.4.0',
+        'django-model-utils==2.3.1',
         'pandas>=0.12.0',
     ],
     classifiers=[
@@ -40,7 +40,7 @@ setup(
     zip_safe=False,
     tests_require=[
         "Django>=1.4.2",
-        "django-model-utils>=1.4.0",
+        "django-model-utils==2.3.1",
         "pandas>=0.12.0",
                    ],
     test_suite="runtests.runtests"

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     py26-django{14,15,16},
     py27-django14, py27-django15_nosouth,
-    py{27,32,33}-django{15,16,17,18,},
-    py34-django{17,18},
+    py{27,32,33}-django{15,16,17,18,19},
+    py34-django{17,18,19},
 
 [testenv]
 basepython =
@@ -20,6 +20,7 @@ deps =
     django16: Django==1.6.10
     django17: Django==1.7.3
     django18: Django==1.8.2
+    django19: Django==1.9.1
     django{14,15,16}: South==1.0.2
 
 commands = coverage run -a setup.py test


### PR DESCRIPTION
I recently switched an internal project from django 1.8 to django 1.9 and a new exception raises:

```
[...]
File "/usr/local/lib/python3.4/site-packages/django_pandas/managers.py" in to_timeseries
  130.             df = self.to_dataframe(fieldnames, verbose=verbose, index=index)

File "/usr/local/lib/python3.4/site-packages/django_pandas/managers.py" in to_dataframe
  181.                           index_col=index, coerce_float=coerce_float)

File "/usr/local/lib/python3.4/site-packages/django_pandas/io.py" in read_frame
  67.     elif isinstance(qs, django.db.models.query.ValuesQuerySet):

Exception Type: AttributeError at [url]
Exception Value: 'module' object has no attribute 'ValuesQuerySet'
```
After digging around django code, I noticed that `ValuesQuerySet` was removed in favor of `ValuesIterable`. This PR fixes this issue.