### PR TITLE
Minor fix to pandas.io.to_fields

### DIFF
--- a/django_pandas/io.py
+++ b/django_pandas/io.py
@@ -16,6 +16,9 @@ def to_fields(qs, fieldnames):
                         field = relobj.field
                         model = field.model
                         break
+                else:
+                    field = None
+                    model = None
             else:
                 if (hasattr(field, "one_to_many") and field.one_to_many) or \
                    (hasattr(field, "one_to_one") and field.one_to_one):


### PR DESCRIPTION
Annotated fields with '__' were having choices from previous field, because 'field' variable was not reset.
And, it is generally a good idea to have else when dealing with breaks in the if.