### PR TITLE
Update for pandas 0.20.1 and Django versions up to 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ matrix:
       env: TOXENV=py35-django10
     - python: 3.5
       env: TOXENV=py35-django11
+    - python: 3.6
+      env: TOXENV=py36-django11
 
 
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,81 +18,81 @@ script:
 
 matrix:
   include:
-   - python: 2.7
-     env: TOXENV=py27-django14
-   - python: 2.7
-     env: TOXENV=py27-django15_nosouth
-   - python: 2.7
-     env: TOXENV=py27-django15
-   - python: 2.7
-     env: TOXENV=py27-django16
-   - python: 2.7
-     env: TOXENV=py27-django17
-   - python: 2.7
-     env: TOXENV=py27-django18
-   - python: 2.7
-     env: TOXENV=py27-django19
-   - python: 2.7
-     env: TOXENV=py27-django10
-   - python: 2.7
-     env: TOXENV=py27-django11  
-   - python: 3.3
-     env: TOXENV=py33-django14
-   - python: 3.3
-     env: TOXENV=py33-django15_nosouth
-   - python: 3.3
-     env: TOXENV=py33-django15
-   - python: 3.3
-     env: TOXENV=py33-django16
-   - python: 3.3
-     env: TOXENV=py33-django17
-   - python: 3.3
-     env: TOXENV=py33-django18 
-   - python: 3.4
-     env: TOXENV=py34-django14
-   - python: 3.4
-     env: TOXENV=py34-django15_nosouth
-   - python: 3.4
-     env: TOXENV=py34-django15
-   - python: 3.4
-     env: TOXENV=py34-django16
-   - python: 3.4
-     env: TOXENV=py34-django17
-   - python: 3.4
-     env: TOXENV=py34-django18
-   - python: 3.4
-     env: TOXENV=py34-django19
-   - python: 3.4
-     env: TOXENV=py34-django10
-   - python: 3.4
-     env: TOXENV=py34-django11
-   - python: 3.5
-     env: TOXENV=py35-django14
-   - python: 3.5
-     env: TOXENV=py35-django15_nosouth
-   - python: 3.5
-     env: TOXENV=py35-django15
-   - python: 3.5
-     env: TOXENV=py35-django16
-   - python: 3.5
-     env: TOXENV=py35-django17
-   - python: 3.5
-     env: TOXENV=py35-django18
-   - python: 3.5
-     env: TOXENV=py35-django19
-   - python: 3.5
-     env: TOXENV=py35-django10
-   - python: 3.5
-     env: TOXENV=py35-django11
+    - python: 2.7
+      env: TOXENV=py27-django14
+    - python: 2.7
+      env: TOXENV=py27-django15_nosouth
+    - python: 2.7
+      env: TOXENV=py27-django15
+    - python: 2.7
+      env: TOXENV=py27-django16
+    - python: 2.7
+      env: TOXENV=py27-django17
+    - python: 2.7
+      env: TOXENV=py27-django18
+    - python: 2.7
+      env: TOXENV=py27-django19
+    - python: 2.7
+      env: TOXENV=py27-django10
+    - python: 2.7
+      env: TOXENV=py27-django11  
+    - python: 3.3
+      env: TOXENV=py33-django14
+    - python: 3.3
+      env: TOXENV=py33-django15_nosouth
+    - python: 3.3
+      env: TOXENV=py33-django15
+    - python: 3.3
+      env: TOXENV=py33-django16
+    - python: 3.3
+      env: TOXENV=py33-django17
+    - python: 3.3
+      env: TOXENV=py33-django18 
+    - python: 3.4
+      env: TOXENV=py34-django14
+    - python: 3.4
+      env: TOXENV=py34-django15_nosouth
+    - python: 3.4
+      env: TOXENV=py34-django15
+    - python: 3.4
+      env: TOXENV=py34-django16
+    - python: 3.4
+      env: TOXENV=py34-django17
+    - python: 3.4
+      env: TOXENV=py34-django18
+    - python: 3.4
+      env: TOXENV=py34-django19
+    - python: 3.4
+      env: TOXENV=py34-django10
+    - python: 3.4
+      env: TOXENV=py34-django11
+    - python: 3.5
+      env: TOXENV=py35-django14
+    - python: 3.5
+      env: TOXENV=py35-django15_nosouth
+    - python: 3.5
+      env: TOXENV=py35-django15
+    - python: 3.5
+      env: TOXENV=py35-django16
+    - python: 3.5
+      env: TOXENV=py35-django17
+    - python: 3.5
+      env: TOXENV=py35-django18
+    - python: 3.5
+      env: TOXENV=py35-django19
+    - python: 3.5
+      env: TOXENV=py35-django10
+    - python: 3.5
+      env: TOXENV=py35-django11
    allow_failures:
-   - python: 3.5
-     env: TOXENV=py35-django14
-   - python: 3.5
-     env: TOXENV=py35-django15_nosouth
-   - python: 3.5
-     env: TOXENV=py35-django16
-   - python: 3.5
-     env: TOXENV=py35-django17
+    - python: 3.5
+      env: TOXENV=py35-django14
+    - python: 3.5
+      env: TOXENV=py35-django15_nosouth
+    - python: 3.5
+      env: TOXENV=py35-django16
+    - python: 3.5
+      env: TOXENV=py35-django17
 
 
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,6 @@ script:
 matrix:
   include:
     - python: 2.7
-      env: TOXENV=py27-django14
-    - python: 2.7
-      env: TOXENV=py27-django15_nosouth
-    - python: 2.7
-      env: TOXENV=py27-django15
-    - python: 2.7
-      env: TOXENV=py27-django16
-    - python: 2.7
-      env: TOXENV=py27-django17
-    - python: 2.7
       env: TOXENV=py27-django18
     - python: 2.7
       env: TOXENV=py27-django19
@@ -31,27 +21,7 @@ matrix:
     - python: 2.7
       env: TOXENV=py27-django11  
     - python: 3.3
-      env: TOXENV=py33-django14
-    - python: 3.3
-      env: TOXENV=py33-django15_nosouth
-    - python: 3.3
-      env: TOXENV=py33-django15
-    - python: 3.3
-      env: TOXENV=py33-django16
-    - python: 3.3
-      env: TOXENV=py33-django17
-    - python: 3.3
       env: TOXENV=py33-django18 
-    - python: 3.4
-      env: TOXENV=py34-django14
-    - python: 3.4
-      env: TOXENV=py34-django15_nosouth
-    - python: 3.4
-      env: TOXENV=py34-django15
-    - python: 3.4
-      env: TOXENV=py34-django16
-    - python: 3.4
-      env: TOXENV=py34-django17
     - python: 3.4
       env: TOXENV=py34-django18
     - python: 3.4
@@ -61,16 +31,6 @@ matrix:
     - python: 3.4
       env: TOXENV=py34-django11
     - python: 3.5
-      env: TOXENV=py35-django14
-    - python: 3.5
-      env: TOXENV=py35-django15_nosouth
-    - python: 3.5
-      env: TOXENV=py35-django15
-    - python: 3.5
-      env: TOXENV=py35-django16
-    - python: 3.5
-      env: TOXENV=py35-django17
-    - python: 3.5
       env: TOXENV=py35-django18
     - python: 3.5
       env: TOXENV=py35-django19
@@ -78,15 +38,6 @@ matrix:
       env: TOXENV=py35-django10
     - python: 3.5
       env: TOXENV=py35-django11
-  allow_failures:
-    - python: 3.5
-      env: TOXENV=py35-django14
-    - python: 3.5
-      env: TOXENV=py35-django15_nosouth
-    - python: 3.5
-      env: TOXENV=py35-django16
-    - python: 3.5
-      env: TOXENV=py35-django17
 
 
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,37 +6,93 @@ python:
   - 3.3
   - 3.4
 
-env:
-  - DJANGO=Django==1.4.22
-  - DJANGO=Django==1.5.12
-  - DJANGO=Django==1.6.11
-  - DJANGO=Django==1.7.11
-  - DJANGO=Django==1.8.9
-  - DJANGO=Django==1.9.2
-
 install:
-  - pip install $DJANGO
+  - pip install --upgrade pip
+  - pip install --upgrade setuptools tox virtualenv
   - pip install coverage coveralls
   - pip install numpy>=1.6.1
-  - pip install pandas>=0.12.0
+  - pip install pandas>=0.20.1
 
 script:
-  - coverage run -a setup.py test
-  - coverage report
+  - tox
+
 matrix:
-  exclude:
-   - python: 2.6
-     env: DJANGO=Django==1.7.11
-   - python: 2.6
-     env: DJANGO=Django==1.8.9
-   - python: 2.6
-     env: DJANGO=Django==1.9.2
-   - python: 3.2
-     env: DJANGO=Django==1.4.22
+  include:
+   - python: 2.7
+     env: TOXENV=py27-django14
+   - python: 2.7
+     env: TOXENV=py27-django15_nosouth
+   - python: 2.7
+     env: TOXENV=py27-django15
+   - python: 2.7
+     env: TOXENV=py27-django16
+   - python: 2.7
+     env: TOXENV=py27-django17
+   - python: 2.7
+     env: TOXENV=py27-django18
+   - python: 2.7
+     env: TOXENV=py27-django19
+   - python: 2.7
+     env: TOXENV=py27-django10
+   - python: 2.7
+     env: TOXENV=py27-django11  
    - python: 3.3
-     env: DJANGO=Django==1.4.22
+     env: TOXENV=py33-django14
    - python: 3.3
-     env: DJANGO=Django==1.9.2
+     env: TOXENV=py33-django15_nosouth
+   - python: 3.3
+     env: TOXENV=py33-django15
+   - python: 3.3
+     env: TOXENV=py33-django16
+   - python: 3.3
+     env: TOXENV=py33-django17
+   - python: 3.3
+     env: TOXENV=py33-django18 
    - python: 3.4
-     env: DJANGO=Django==1.4.22
+     env: TOXENV=py34-django14
+   - python: 3.4
+     env: TOXENV=py34-django15_nosouth
+   - python: 3.4
+     env: TOXENV=py34-django15
+   - python: 3.4
+     env: TOXENV=py34-django16
+   - python: 3.4
+     env: TOXENV=py34-django17
+   - python: 3.4
+     env: TOXENV=py34-django18
+   - python: 3.4
+     env: TOXENV=py34-django19
+   - python: 3.4
+     env: TOXENV=py34-django10
+   - python: 3.4
+     env: TOXENV=py34-django11
+   - python: 3.5
+     env: TOXENV=py35-django14
+   - python: 3.5
+     env: TOXENV=py35-django15_nosouth
+   - python: 3.5
+     env: TOXENV=py35-django15
+   - python: 3.5
+     env: TOXENV=py35-django16
+   - python: 3.5
+     env: TOXENV=py35-django17
+   - python: 3.5
+     env: TOXENV=py35-django18
+   - python: 3.5
+     env: TOXENV=py35-django19
+   - python: 3.5
+     env: TOXENV=py35-django10
+   - python: 3.5
+     env: TOXENV=py35-django11
+   allow_failures:
+   - python: 3.5
+     env: TOXENV=py35-django14
+   - python: 3.5
+     env: TOXENV=py35-django15_nosouth
+   - python: 3.5
+     env: TOXENV=py35-django16
+   - python: 3.5
+     env: TOXENV=py35-django17
+
+
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ matrix:
       env: TOXENV=py27-django10
     - python: 2.7
       env: TOXENV=py27-django11  
-    - python: 3.3
-      env: TOXENV=py33-django18 
     - python: 3.4
       env: TOXENV=py34-django18
     - python: 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,25 @@ script:
 matrix:
   include:
     - python: 2.7
+      env: TOXENV=py27-django14
+    - python: 2.7
+      env: TOXENV=py27-django15_nosouth
+    - python: 2.7
+      env: TOXENV=py27-django15
+    - python: 2.7
+      env: TOXENV=py27-django16
+    - python: 2.7
+      env: TOXENV=py27-django17
+    - python: 2.7
       env: TOXENV=py27-django18
     - python: 2.7
       env: TOXENV=py27-django19
     - python: 2.7
       env: TOXENV=py27-django10
     - python: 2.7
-      env: TOXENV=py27-django11  
+      env: TOXENV=py27-django11 
+    - python: 3.4
+      env: TOXENV=py34-django17 
     - python: 3.4
       env: TOXENV=py34-django18
     - python: 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
 language: python
 
-python:
-  - 2.6
-  - 2.7
-  - 3.3
-  - 3.4
-
 install:
   - pip install --upgrade pip
   - pip install --upgrade setuptools tox virtualenv
@@ -84,7 +78,7 @@ matrix:
       env: TOXENV=py35-django10
     - python: 3.5
       env: TOXENV=py35-django11
-   allow_failures:
+  allow_failures:
     - python: 3.5
       env: TOXENV=py35-django14
     - python: 3.5

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,6 +8,7 @@ Development Lead
 
 Contributions
 ``````````````
+
 - `Christopher Clarke <https://github.com/chrisdev>`_
 - `Bertrand Bordage <https://github.com/BertrandBordage>`_
 - `Guillaume Thomas <https://github.com/gtnx>`_
@@ -16,3 +17,4 @@ Contributions
 - `Safe Hammad <http://safehammad.com>`_
 - `Jeff Sternber <https://www.linkedin.com/in/jeffsternberg>`_
 - `@MiddleFork <https://github.com/MiddleFork>`_
+- `Daniel Andrlik <https://github.com/andrlik>`

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -17,4 +17,4 @@ Contributions
 - `Safe Hammad <http://safehammad.com>`_
 - `Jeff Sternber <https://www.linkedin.com/in/jeffsternberg>`_
 - `@MiddleFork <https://github.com/MiddleFork>`_
-- `Daniel Andrlik <https://github.com/andrlik>`
+- `Daniel Andrlik <https://github.com/andrlik>`_

--- a/django_pandas/tests/test_io.py
+++ b/django_pandas/tests/test_io.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+import django
 from django.db.models import Sum
 import pandas as pd
 import numpy as np
@@ -34,10 +35,13 @@ class IOTest(TestCase):
         n, c = df.shape
         self.assertEqual(n, qs.count())
         from itertools import chain
-        fields = list(set(chain.from_iterable((field.name, field.attname) if hasattr(field,'attname') else (field.name,)
-            for field in MyModel._meta.get_fields()
-            if not (field.many_to_one and field.related_model is None)
-        )))
+        if django.VERSION < (1,10):
+            fields = MyModel._meta.get_all_field_names()
+        else:
+            fields = list(set(chain.from_iterable((field.name, field.attname) if hasattr(field,'attname') else (field.name,)
+                for field in MyModel._meta.get_fields()
+                if not (field.many_to_one and field.related_model is None)
+            )))
         self.assertEqual(c, len(fields))
         df1 = read_frame(qs, ['col1', 'col2'])
         self.assertEqual(df1.shape, (qs.count(), 2))

--- a/django_pandas/tests/test_io.py
+++ b/django_pandas/tests/test_io.py
@@ -33,7 +33,11 @@ class IOTest(TestCase):
         df = read_frame(qs)
         n, c = df.shape
         self.assertEqual(n, qs.count())
-        fields = MyModel._meta.get_all_field_names()
+        from itertools import chain
+        fields = list(set(chain.from_iterable((field.name, field.attname) if hasattr(field,'attname') else (field.name,)
+            for field in MyModel._meta.get_fields()
+            if not (field.many_to_one and field.related_model is None)
+        )))
         self.assertEqual(c, len(fields))
         df1 = read_frame(qs, ['col1', 'col2'])
         self.assertEqual(df1.shape, (qs.count(), 2))

--- a/django_pandas/tests/test_manager.py
+++ b/django_pandas/tests/test_manager.py
@@ -38,7 +38,11 @@ class DataFrameTest(TestCase):
 
         n, c = df.shape
         self.assertEqual(n, qs.count())
-        flds = DataFrame._meta.get_all_field_names()
+        from itertools import chain
+        flds = list(set(chain.from_iterable((field.name, field.attname) if hasattr(field,'attname') else (field.name,)
+            for field in DataFrame._meta.get_fields()
+            if not (field.many_to_one and field.related_model is None)
+        )))
         self.assertEqual(c, len(flds))
         qs2 = DataFrame.objects.filter(index__in=['a', 'b', 'c'])
         df2 = qs2.to_dataframe(['col1', 'col2', 'col3'], index='index')

--- a/django_pandas/tests/test_manager.py
+++ b/django_pandas/tests/test_manager.py
@@ -84,7 +84,7 @@ class TimeSeriesTest(TestCase):
         df = qs.to_timeseries(index='date_ix', storage='wide')
 
         self.assertEqual(df.shape, (qs.count(), 5))
-        self.assertIsInstance(df.index, pd.tseries.index.DatetimeIndex)
+        self.assertIsInstance(df.index, pd.DatetimeIndex)
         self.assertIsNone(df.index.freq)
 
     def test_longstorage(self):
@@ -96,7 +96,7 @@ class TimeSeriesTest(TestCase):
                          set(df.columns.tolist()))
 
         self.assertEqual(qs.filter(series_name='A').count(), len(df['A']))
-        self.assertIsInstance(df.index, pd.tseries.index.DatetimeIndex)
+        self.assertIsInstance(df.index, pd.DatetimeIndex)
         self.assertIsNone(df.index.freq)
 
     def test_resampling(self):
@@ -109,7 +109,7 @@ class TimeSeriesTest(TestCase):
         self.assertEqual([d.month for d in qs.dates('date_ix', 'month')],
                          df.index.month.tolist())
 
-        self.assertIsInstance(df.index, pd.tseries.period.PeriodIndex)
+        self.assertIsInstance(df.index, pd.PeriodIndex)
         #try on a  wide time seriesd
 
         qs2 = WideTimeSeries.objects.all()
@@ -120,7 +120,7 @@ class TimeSeriesTest(TestCase):
         self.assertEqual([d.month for d in qs.dates('date_ix', 'month')],
                          df1.index.month.tolist())
 
-        self.assertIsInstance(df1.index, pd.tseries.period.PeriodIndex)
+        self.assertIsInstance(df1.index, pd.PeriodIndex)
 
     def test_bad_args_wide_ts(self):
         qs = WideTimeSeries.objects.all()

--- a/django_pandas/tests/test_manager.py
+++ b/django_pandas/tests/test_manager.py
@@ -39,10 +39,13 @@ class DataFrameTest(TestCase):
         n, c = df.shape
         self.assertEqual(n, qs.count())
         from itertools import chain
-        flds = list(set(chain.from_iterable((field.name, field.attname) if hasattr(field,'attname') else (field.name,)
-            for field in DataFrame._meta.get_fields()
-            if not (field.many_to_one and field.related_model is None)
-        )))
+        if django.VERSION < (1,10):
+            flds = DataFrame._meta.get_all_field_names()
+        else:
+            flds = list(set(chain.from_iterable((field.name, field.attname) if hasattr(field,'attname') else (field.name,)
+                for field in DataFrame._meta.get_fields()
+                if not (field.many_to_one and field.related_model is None)
+            )))
         self.assertEqual(c, len(flds))
         qs2 = DataFrame.objects.filter(index__in=['a', 'b', 'c'])
         df2 = qs2.to_dataframe(['col1', 'col2', 'col3'], index='index')

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     zip_safe=False,
     tests_require=[
         "Django>=1.4.2",
-        "pandas>=0.14.1",
+        "pandas==0.14.1",
         "coverage>=4.0",
                    ],
     test_suite="runtests.runtests"

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     zip_safe=False,
     tests_require=[
         "Django>=1.4.2",
-        "pandas==0.14.1",
+        "pandas==0.20.1",
         "coverage>=4.0",
                    ],
     test_suite="runtests.runtests"

--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,17 @@
 [tox]
 envlist =
-    py26-django{14,15,16},
-    py27-django14, py27-django15_nosouth,
-    py{27,32,33}-django{15,16,17,18,19},
-    py34-django{17,18,19},
+    py{27,35}-django{18,19,10,11},
 
 [testenv]
 basepython =
-    py26: python2.6
     py27: python2.7
-    py32: python3.2
-    py33: python3.3
-    py34: python3.4
+    py35: python3.5
 
 deps =
     coverage == 4.0.3 
-    django14: Django==1.4.22
-    django15{,_nosouth}: Django==1.5.12
-    django16: Django==1.6.11
-    django17: Django==1.7.11
     django18: Django==1.8.9
     django19: Django==1.9.2
-    django{14,15,16}: South==1.0.2
+    django10: Django>=1.10,<1.11
+    django11: Django>=1.11,<1.12
 
 commands = coverage run -a setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ basepython =
     py33: python3.3
     py34: python3.4
     py35: python3.5
+    py36: python3.6
 
 deps =
     coverage == 4.0.3 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,10 @@
 [tox]
 envlist =
-    py{27,32,33}-django{18,19,10,11},
-    py34-django{18,19,10,11},
+    py27-django14, py27-django15_nosouth
+    py27-django{15,16,17,18,19,10,11},
+    py34-django{17,18,19,10,11},
     py35-django{18,19,10,11},
+    py36-django11,
 
 [testenv]
 basepython =
@@ -13,9 +15,14 @@ basepython =
 
 deps =
     coverage == 4.0.3 
+    django14: Django==1.4.22
+    django15{,_nosouth}: Django==1.5.12
+    django16: Django==1.6.11
+    django17: Django==1.7.11
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django10: Django>=1.10,<1.11
     django11: Django>=1.11,<1.12
+    django{14,15,16}: South==1.0.2
 
 commands = coverage run -a setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,28 @@
 [tox]
 envlist =
-    py{27,35}-django{18,19,10,11},
+    py27-django14, py27-django15_nosouth,
+    py{27,32,33}-django{15,16,17,18,19,10,11},
+    py34-django{17,18,19,10,11},
+    py35-django{18,19,10,11},
 
 [testenv]
 basepython =
     py27: python2.7
+    py32: python3.2
+    py33: python3.3
+    py34: python3.4
     py35: python3.5
 
 deps =
     coverage == 4.0.3 
-    django18: Django==1.8.9
-    django19: Django==1.9.2
+    django14: Django==1.4.22
+    django15{,_nosouth}: Django==1.5.12
+    django16: Django==1.6.11
+    django17: Django==1.7.11
+    django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
     django10: Django>=1.10,<1.11
     django11: Django>=1.11,<1.12
+    django{14,15,16}: South==1.0.2
 
 commands = coverage run -a setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,6 @@ envlist =
 [testenv]
 basepython =
     py27: python2.7
-    py32: python3.2
-    py33: python3.3
     py34: python3.4
     py35: python3.5
     py36: python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 envlist =
-    py27-django14, py27-django15_nosouth,
-    py{27,32,33}-django{15,16,17,18,19,10,11},
-    py34-django{17,18,19,10,11},
+    py{27,32,33}-django{18,19,10,11},
+    py34-django{18,19,10,11},
     py35-django{18,19,10,11},
 
 [testenv]
@@ -15,14 +14,9 @@ basepython =
 
 deps =
     coverage == 4.0.3 
-    django14: Django==1.4.22
-    django15{,_nosouth}: Django==1.5.12
-    django16: Django==1.6.11
-    django17: Django==1.7.11
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django10: Django>=1.10,<1.11
     django11: Django>=1.11,<1.12
-    django{14,15,16}: South==1.0.2
 
 commands = coverage run -a setup.py test


### PR DESCRIPTION
Update for compatibility with pandas 0.20.1 and Django versions up to 1.11. pandas now only provides python support for 2.7, or 3.4 and above. Updated the tests in travis and tox to reflect that, and added a test run for 3.6 since 1.11 also supports that version. With the exception of the python version requirements, all other backwards compatibility remains the same.