### PR TITLE
Added compatibility if verbose name cannot be found in model

### DIFF
--- a/django_pandas/io.py
+++ b/django_pandas/io.py
@@ -10,12 +10,16 @@ def to_fields(qs, fieldnames):
             try:
                 field = model._meta.get_field(fieldname_part)
             except django.db.models.fields.FieldDoesNotExist:
-                rels = model._meta.get_all_related_objects_with_model()
-                for relobj, _ in rels:
-                    if relobj.get_accessor_name() == fieldname_part:
-                        field = relobj.field
-                        model = field.model
-                        break
+                try:
+                    rels = model._meta.get_all_related_objects_with_model()
+                except AttributeError:
+                    field = fieldname
+                else:
+                    for relobj, _ in rels:
+                        if relobj.get_accessor_name() == fieldname_part:
+                            field = relobj.field
+                            model = field.model
+                            break
             else:
                 if (hasattr(field, "one_to_many") and field.one_to_many) or \
                    (hasattr(field, "one_to_one") and field.one_to_one):

--- a/django_pandas/io.py
+++ b/django_pandas/io.py
@@ -5,23 +5,21 @@ import django
 
 def to_fields(qs, fieldnames):
     for fieldname in fieldnames:
-        field = fieldname
         model = qs.model
         for fieldname_part in fieldname.split('__'):
             try:
                 field = model._meta.get_field(fieldname_part)
             except django.db.models.fields.FieldDoesNotExist:
-                rels = [
-                    (f, f.model if f.model != model else None)
-                    for f in model._meta.get_fields()
-                    if (f.one_to_many or f.one_to_one)
-                    and f.auto_created and not f.concrete
-                ]
-                for relobj, _ in rels:
-                    if relobj.get_accessor_name() == fieldname_part:
-                        field = relobj.field
-                        model = field.model
-                        break
+                try:
+                    rels = model._meta.get_all_related_objects_with_model()
+                except AttributeError:
+                    field = fieldname
+                else:
+                    for relobj, _ in rels:
+                        if relobj.get_accessor_name() == fieldname_part:
+                            field = relobj.field
+                            model = field.model
+                            break
             else:
                 if (hasattr(field, "one_to_many") and field.one_to_many) or \
                    (hasattr(field, "one_to_one") and field.one_to_one):

--- a/django_pandas/tests/test_io.py
+++ b/django_pandas/tests/test_io.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 import django
-from django.db.models import Sum
+from django.db.models import Sum, F, FloatField
+from django.db.models.functions import Cast
 import pandas as pd
 import numpy as np
 from .models import MyModel, Trader, Security, TradeLog, TradeLogNote, MyModelChoice, Portfolio
@@ -148,6 +149,21 @@ class RelatedFieldsTest(TestCase):
         self.assertListEqual(
             list(qs.values_list('trader__pk', flat=True)),
             df1.trader.tolist()
+        )
+        
+        # Testing verbose with annotated column:
+        qs1 = TradeLog.objects.all().annotate(
+            total_sum=Cast(F('price') * F('volume'), FloatField()),
+        )
+        df2 = read_frame(
+            qs1, fieldnames=['trader', 'total_sum'])
+        self.assertListEqual(
+            list(qs1.values_list('total_sum', flat=True)),
+            df2.total_sum.tolist()
+        )
+        self.assertListEqual(
+            list(qs1.values_list('trader__name', flat=True)),
+            df2.trader.tolist()
         )
 
     def test_related_cols(self):


### PR DESCRIPTION
If a query-set with annotated columns is used with django_pandas and we want to activate verbose names there is an error. First, the algorithm tries to look up fields, if that fails it tries look-up via old-django-style using _meta.get_all_related_objects_with_model()_ which then results in an error.
(See my issue #81 )

The code below solves this problem, but I'm not sure if it fulfills your programming standards?!