### PR TITLE
Values QS read_frame: Don't do verbose lookup on related fields

### DIFF
--- a/django_pandas/io.py
+++ b/django_pandas/io.py
@@ -93,7 +93,8 @@ def read_frame(qs, fieldnames=(), index_col=None, coerce_float=False,
 
             fieldnames = qs.field_names + annotation_field_names + extra_names
 
-            fields = [qs.model._meta.get_field(f) for f in qs.field_names] + \
+            fields = [None if '__' in f else qs.model._meta.get_field(f)
+                      for f in qs.field_names] + \
                 [None] * (len(annotation_field_names) + len(extra_names))
 
         else:
@@ -105,8 +106,8 @@ def read_frame(qs, fieldnames=(), index_col=None, coerce_float=False,
             fieldnames = select_field_names + annotation_field_names \
                 + extra_field_names
 
-            fields = [qs.model._meta.get_field(f) for
-                      f in select_field_names] + \
+            fields = [None if '__' in f else qs.model._meta.get_field(f)
+                      for f in select_field_names] + \
                 [None] * (len(annotation_field_names) + len(extra_field_names))
     else:
         fields = qs.model._meta.fields

--- a/django_pandas/tests/test_io.py
+++ b/django_pandas/tests/test_io.py
@@ -168,6 +168,11 @@ class RelatedFieldsTest(TestCase):
                 df2.trader.tolist()
             )
 
+    def test_related_selected_field(self):
+        qs = TradeLog.objects.all().values('trader__name')
+        df = read_frame(qs)
+        self.assertEqual(list(df.columns), ['trader__name'])
+
     def test_related_cols(self):
         qs = TradeLog.objects.all()
         cols = ['log_datetime', 'symbol', 'symbol__isin', 'trader__name',


### PR DESCRIPTION
- Related fields (fieldnames containing "__") cannot be accessed in qs.model._meta.get_field. These fields can't be replaced with verbose versions, anyways, so just use none in fields
- Add test around values qs with related_field
- passes tests