### PR TITLE
DataFrameManager.to_timeseries() - coerce float option added

### DIFF
--- a/django_pandas/managers.py
+++ b/django_pandas/managers.py
@@ -133,7 +133,7 @@ class DataFrameQuerySet(QuerySet):
     def to_timeseries(self, fieldnames=(), verbose=True,
                       index=None, storage='wide',
                       values=None, pivot_columns=None, freq=None,
-                      rs_kwargs=None):
+                      coerce_float=False, rs_kwargs=None):
         """
         A convenience method for creating a time series DataFrame i.e the
         DataFrame index will be an instance of  DateTime or PeriodIndex
@@ -197,6 +197,9 @@ class DataFrameQuerySet(QuerySet):
                   human readable versions of any foreign key fields else use
                   the primary keys values else use the actual values set
                   in the model.
+                  
+        coerce_float:   Attempt to convert values to non-string, non-numeric
+                        objects (like decimal.Decimal) to floating point.
         """
         assert index is not None, 'You must supply an index field'
         assert storage in ('wide', 'long'), 'storage must be wide or long'
@@ -204,9 +207,11 @@ class DataFrameQuerySet(QuerySet):
             rs_kwargs = {}
 
         if storage == 'wide':
-            df = self.to_dataframe(fieldnames, verbose=verbose, index=index)
+            df = self.to_dataframe(fieldnames, verbose=verbose, index=index,
+                                   coerce_float=True)
         else:
-            df = self.to_dataframe(fieldnames, verbose=verbose)
+            df = self.to_dataframe(fieldnames, verbose=verbose,
+                                   coerce_float=True)
             assert values is not None, 'You must specify a values field'
             assert pivot_columns is not None, 'You must specify pivot_columns'
 
@@ -252,6 +257,9 @@ class DataFrameQuerySet(QuerySet):
         verbose: If  this is ``True`` then populate the DataFrame with the
                  human readable versions for foreign key fields else
                  use the actual values set in the model
+        
+        coerce_float:   Attempt to convert values to non-string, non-numeric 
+                        objects (like decimal.Decimal) to floating point.
         """
 
         return read_frame(self, fieldnames=fieldnames, verbose=verbose,

--- a/django_pandas/tests/test_manager.py
+++ b/django_pandas/tests/test_manager.py
@@ -156,7 +156,20 @@ class TimeSeriesTest(TestCase):
         ##df = qs.to_timeseries(index='date_ix', pivot_columns='series_name',
                                 ##values='value',
                                 ##storage='long')
+    
+    def test_coerce_float(self):
+        qs = LongTimeSeries.objects.all()
+        ts = qs.to_timeseries(index='date_ix', coerce_float=True).resample('D').sum()
+        self.assertEqual(ts['value'].dtype, np.float64)
 
+        # Testing on Wide Series
+
+        qs = WideTimeSeries.objects.all()
+        ts = qs.to_timeseries(index='date_ix', coerce_float=True).resample('D').sum()
+        self.assertEqual(ts['col1'].dtype, np.float64)
+        self.assertEqual(ts['col2'].dtype, np.float64)
+        self.assertEqual(ts['col3'].dtype, np.float64)
+        self.assertEqual(ts['col4'].dtype, np.float64)
 
 class PivotTableTest(TestCase):
 


### PR DESCRIPTION
We were unable to perform aggregate functions on timeseries decimal fields because they were being read as text fields. coerce_float=True option on timeseries allows aggregation

Please not that this is a pull request for #79 and also address issues for #80 