### PR TITLE
read_frame: Fix fieldname deduplication bug

### DIFF
--- a/django_pandas/tests/test_io.py
+++ b/django_pandas/tests/test_io.py
@@ -168,6 +168,23 @@ class RelatedFieldsTest(TestCase):
                 df2.trader.tolist()
             )
 
+    def test_verbose_duplicates_fieldnames(self):
+        qs = TradeLog.objects.all()
+        df = read_frame(qs, fieldnames=['trader', 'trader', 'price'])
+        self.assertListEqual(
+            list(qs.values_list('price', flat=True)),
+            df.price.tolist()
+        )
+
+    def test_verbose_duplicate_values(self):
+        qs = TradeLog.objects.all()
+        qs = qs.values('trader', 'trader', 'price')
+        df = read_frame(qs)
+        self.assertListEqual(
+            list(qs.values_list('price', flat=True)),
+            df.price.tolist()
+        )
+
     def test_related_selected_field(self):
         qs = TradeLog.objects.all().values('trader__name')
         df = read_frame(qs)


### PR DESCRIPTION
- The previous method of deduplicating fieldnames caused issues by creating offsets between a field's index in the fieldnames and fields lists. This resulted in update_with_verbose function doing a verbose lookup on a fieldname using the wrong field object, thus replacing with completely wrong data. This would happen if:
    1. There were duplicates in the fieldnames parameter. This is solved by removing duplicates 
before calling to_fields
    2. There were duplicates in select_field_names, annotation_field_names, extra_field_names. This is solved by removing duplicated (fieldname, field) pairs using the fieldname the required unique
- Adds tests around bug cases
- passes tests