### PR TITLE
Remove Django<1.8 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
-  # - "3.6"
-  # - "3.7"
+  - "3.6"
+  - "3.7"
 
 env:
   matrix:
@@ -27,6 +27,8 @@ script:
   - tox -e py${TRAVIS_PYTHON_VERSION}-django${DJANGO}
 
 matrix:
+  allow_failures:
+    - python: "3.7"
   exclude:
     - python: "2.7"
       env: DJANGO=20

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,21 @@
 language: python
 
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  # - "3.6"
+  # - "3.7"
+
+env:
+  matrix:
+    - DJANGO=18
+    - DJANGO=19
+    - DJANGO=110
+    - DJANGO=111
+    - DJANGO=20
+    - DJANGO=21
+
 install:
   - pip install --upgrade pip
   - pip install --upgrade setuptools tox virtualenv
@@ -8,49 +24,35 @@ install:
   - pip install pandas>=0.20.1
 
 script:
-  - tox
+  - tox -e py${TRAVIS_PYTHON_VERSION}-django${DJANGO}
 
 matrix:
-  include:
-    - python: 2.7
-      env: TOXENV=py27-django14
-    - python: 2.7
-      env: TOXENV=py27-django15_nosouth
-    - python: 2.7
-      env: TOXENV=py27-django15
-    - python: 2.7
-      env: TOXENV=py27-django16
-    - python: 2.7
-      env: TOXENV=py27-django17
-    - python: 2.7
-      env: TOXENV=py27-django18
-    - python: 2.7
-      env: TOXENV=py27-django19
-    - python: 2.7
-      env: TOXENV=py27-django10
-    - python: 2.7
-      env: TOXENV=py27-django11
-    - python: 3.4
-      env: TOXENV=py34-django17
-    - python: 3.4
-      env: TOXENV=py34-django18
-    - python: 3.4
-      env: TOXENV=py34-django19
-    - python: 3.4
-      env: TOXENV=py34-django10
-    - python: 3.4
-      env: TOXENV=py34-django11
-    - python: 3.5
-      env: TOXENV=py35-django18
-    - python: 3.5
-      env: TOXENV=py35-django19
-    - python: 3.5
-      env: TOXENV=py35-django10
-    - python: 3.5
-      env: TOXENV=py35-django11
-    - python: 3.6
-      env: TOXENV=py36-django11
-    - python: 3.7-django
-      env: TOXENV=py37-django20
+  exclude:
+    - python: "2.7"
+      env: DJANGO=20
+    - python: "2.7"
+      env: DJANGO=21
+    - python: "3.4"
+      env: DJANGO=20
+    - python: "3.4"
+      env: DJANGO=21
+    - python: "3.6"
+      env: DJANGO=18
+    - python: "3.6"
+      env: DJANGO=19
+    - python: "3.6"
+      env: DJANGO=110
+    - python: "3.7"
+      env: DJANGO=18
+    - python: "3.7"
+      env: DJANGO=19
+    - python: "3.7"
+      env: DJANGO=110
+    - python: "3.7"
+      env: DJANGO=111
+    - python: "2.7"
+      env: DJANGO=20
+    - python: "2.7"
+      env: DJANGO=21
 
 after_success: coveralls

--- a/django_pandas/io.py
+++ b/django_pandas/io.py
@@ -75,10 +75,7 @@ def read_frame(qs, fieldnames=(), index_col=None, coerce_float=False,
         fields = to_fields(qs, fieldnames)
     elif is_values_queryset(qs):
         if django.VERSION < (1, 9):  # pragma: no cover
-            if django.VERSION < (1, 8):
-                annotation_field_names = qs.aggregate_names
-            else:
-                annotation_field_names = list(qs.query.annotation_select)
+            annotation_field_names = list(qs.query.annotation_select)
 
             if annotation_field_names is None:
                 annotation_field_names = []
@@ -107,10 +104,7 @@ def read_frame(qs, fieldnames=(), index_col=None, coerce_float=False,
     else:
         fields = qs.model._meta.fields
         fieldnames = [f.name for f in fields]
-        if django.VERSION < (1, 8):  # pragma: no cover
-            fieldnames += list(qs.query.aggregate_select.keys())
-        else:
-            fieldnames += list(qs.query.annotation_select.keys())
+        fieldnames += list(qs.query.annotation_select.keys())
 
     if is_values_queryset(qs):
         recs = list(qs)

--- a/django_pandas/managers.py
+++ b/django_pandas/managers.py
@@ -19,8 +19,6 @@ class PassThroughManagerMixin(object):
     def __getattr__(self, name):
         if name in self._deny_methods:
             raise AttributeError(name)
-        if django.VERSION < (1, 6, 0):  # pragma: no cover
-            return getattr(self.get_query_set(), name)
         return getattr(self.get_queryset(), name)
 
     def __dir__(self):
@@ -270,10 +268,4 @@ class DataFrameQuerySet(QuerySet):
                           index_col=index, coerce_float=coerce_float)
 
 
-if django.VERSION < (1, 7):  # pragma: no cover
-    class DataFrameManager(PassThroughManager):
-        def get_query_set(self):
-            return DataFrameQuerySet(self.model)
-
-else:  # pragma: no cover
-    DataFrameManager = models.Manager.from_queryset(DataFrameQuerySet)
+DataFrameManager = models.Manager.from_queryset(DataFrameQuerySet)

--- a/django_pandas/utils.py
+++ b/django_pandas/utils.py
@@ -3,18 +3,12 @@
 from django.core.cache import cache
 from django.utils.encoding import force_text
 from django.db.models import Field
-import django
 
 
 def get_model_name(model):
     """
     Returns the name of the model
     """
-    # model._meta.module_name is deprecated in django version
-    # 1.7 and removed in django version 1.8.
-    # It is replaced by model._meta.model_name
-    if django.VERSION < (1, 7):  # pragma: no cover
-        return model._meta.module_name
     return model._meta.model_name
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     py3.4-django{18,19,100,111},
     py3.5-django{18,19,100,111,20,21},
     py3.6-django{111,20,21},
-    #py3.7-django{20,21},
+    py3.7-django{20,21}
 
 [testenv]
 basepython =

--- a/tox.ini
+++ b/tox.ini
@@ -1,30 +1,25 @@
 [tox]
 envlist =
-    py27-django14, py27-django15_nosouth
-    py27-django{15,16,17,18,19,10,11},
-    py34-django{17,18,19,10,11},
-    py35-django{18,19,10,11,20},
-    py36-django{11,20},
-    #py37-django{11,20},
+    py2.7-django{18,19,100,111},
+    py3.4-django{18,19,100,111},
+    py3.5-django{18,19,100,111,20,21},
+    py3.6-django{111,20,21},
+    #py3.7-django{20,21},
 
 [testenv]
 basepython =
-    py27: python2.7
-    py34: python3.4
-    py35: python3.5
-    py36: python3.6
-    #py37: python3.7
+    py2.7: python2.7
+    py3.4: python3.4
+    py3.5: python3.5
+    py3.6: python3.6
+    py3.7: python3.7
 deps =
     coverage == 4.5.2
-    django14: Django==1.4.22
-    django15{,_nosouth}: Django==1.5.12
-    django16: Django==1.6.11
-    django17: Django==1.7.11
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
-    django10: Django>=1.10,<1.11
-    django11: Django>=1.11,<1.12
-    django{14,15,16}: South==1.0.2
-    django20: Django>=2.0,<2.2
+    django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<1.12
+    django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
 
 commands = coverage run -a setup.py test


### PR DESCRIPTION
I changed the logical of the Travis' matrix, now we create a matrix of each Django & Python versions and exclude incompatibilities.

I added tests for Django 2.1.

Don't you think we should make compatibility just with Django>=1.11, as it the last LTS ?