### PR TITLE
Support for transforms in fieldnames

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,6 +9,7 @@ Development Lead
 Contributions
 ``````````````
 
+- `Aaron O. Ellis <https://github.com/aodin>`_
 - `Christopher Clarke <https://github.com/chrisdev>`_
 - `Bertrand Bordage <https://github.com/BertrandBordage>`_
 - `Guillaume Thomas <https://github.com/gtnx>`_

--- a/django_pandas/io.py
+++ b/django_pandas/io.py
@@ -9,7 +9,7 @@ def to_fields(qs, fieldnames):
         for fieldname_part in fieldname.split('__'):
             try:
                 field = model._meta.get_field(fieldname_part)
-            except django.db.models.fields.FieldDoesNotExist:
+            except (django.db.models.fields.FieldDoesNotExist, AttributeError):
                 try:
                     rels = model._meta.get_all_related_objects_with_model()
                 except AttributeError:

--- a/django_pandas/tests/test_io.py
+++ b/django_pandas/tests/test_io.py
@@ -219,3 +219,8 @@ class RelatedFieldsTest(TestCase):
                 df.iloc[idx].tolist(),
                 list(row)
             )
+
+    def  test_transforms(self):
+        qs = TradeLog.objects.all()
+        df = read_frame(qs, fieldnames=['log_datetime__year'])
+        self.assertEqual(list(df.columns), ['log_datetime__year'])

--- a/django_pandas/tests/test_io.py
+++ b/django_pandas/tests/test_io.py
@@ -220,7 +220,11 @@ class RelatedFieldsTest(TestCase):
                 list(row)
             )
 
-    def  test_transforms(self):
+    def test_transforms(self):
         qs = TradeLog.objects.all()
-        df = read_frame(qs, fieldnames=['log_datetime__year'])
-        self.assertEqual(list(df.columns), ['log_datetime__year'])
+        if django.VERSION >= (2, 1):
+            df = read_frame(qs, fieldnames=['log_datetime__year'])
+            self.assertEqual(list(df.columns), ['log_datetime__year'])
+        else:
+            with self.assertRaises(django.core.exceptions.FieldError):
+                read_frame(qs, fieldnames=['log_datetime__year'])

--- a/django_pandas/tests/test_manager.py
+++ b/django_pandas/tests/test_manager.py
@@ -188,6 +188,11 @@ class TimeSeriesTest(TestCase):
         self.assertEqual(ts['col3'].dtype, np.float64)
         self.assertEqual(ts['col4'].dtype, np.float64)
 
+    def test_transforms_wide_ts(self):
+        ts = WideTimeSeries.objects.to_timeseries(index='date_ix',
+                                                  fieldnames=['date_ix__year'])
+        self.assertEqual(ts['date_ix__year'].dtype, np.int64)
+
 
 class PivotTableTest(TestCase):
 

--- a/django_pandas/tests/test_manager.py
+++ b/django_pandas/tests/test_manager.py
@@ -189,9 +189,14 @@ class TimeSeriesTest(TestCase):
         self.assertEqual(ts['col4'].dtype, np.float64)
 
     def test_transforms_wide_ts(self):
-        ts = WideTimeSeries.objects.to_timeseries(index='date_ix',
-                                                  fieldnames=['date_ix__year'])
-        self.assertEqual(ts['date_ix__year'].dtype, np.int64)
+        if django.VERSION >= (2, 1):
+            ts = WideTimeSeries.objects.to_timeseries(index='date_ix',
+                                                      fieldnames=['date_ix__year'])
+            self.assertEqual(ts['date_ix__year'].dtype, np.int64)
+        else:
+            with self.assertRaises(django.core.exceptions.FieldError):
+                WideTimeSeries.objects.to_timeseries(index='date_ix',
+                                                     fieldnames=['date_ix__year'])
 
 
 class PivotTableTest(TestCase):


### PR DESCRIPTION
In order to support transforms in fieldnames (e.g. `datetime__year`), I added `AttributeError` to the caught expections of `io.to_fields`. This changes the `try` block to match what is found in the [Django ORM source](https://github.com/django/django/blob/ea071870f943c23a8eaf36dfcdf382afd6478fd1/django/db/models/base.py#L1662), which prevents the `AttributeError` that would be raised by `to_fields` attempting to parse `year` as a related field instead of a transform.

Improper transforms or non-existent relations will still raise `django.core.exceptions.FieldError` during the `try_transform` of query processing in the Django ORM.