### PR TITLE
Support a column_name arg to read_frame to override column names in the resulting DataFrame.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,6 +125,8 @@ read_frame
                 human readable versions of any foreign key or choice fields
                 else use the actual values set in the model.
 
+    - column_names: If not None, use to override the column names in the
+                    DateFrame
 
 Examples
 ^^^^^^^^^

--- a/django_pandas/io.py
+++ b/django_pandas/io.py
@@ -33,7 +33,7 @@ def is_values_queryset(qs):
 
 
 def read_frame(qs, fieldnames=(), index_col=None, coerce_float=False,
-               verbose=True, datetime_index=False):
+               verbose=True, datetime_index=False, column_names=None):
     """
     Returns a dataframe from a QuerySet
 
@@ -68,6 +68,9 @@ def read_frame(qs, fieldnames=(), index_col=None, coerce_float=False,
 
     datetime_index: specify whether index should be converted to a
                     DateTimeIndex.
+
+    column_names: If not None, use to override the column names in the
+                  DateFrame
     """
 
     if fieldnames:
@@ -75,6 +78,8 @@ def read_frame(qs, fieldnames=(), index_col=None, coerce_float=False,
         if index_col is not None and index_col not in fieldnames:
             # Add it to the field names if not already there
             fieldnames = tuple(fieldnames) + (index_col,)
+            if column_names:
+                column_names = tuple(column_names) + (index_col,)
         fields = to_fields(qs, fieldnames)
     elif is_values_queryset(qs):
         if django.VERSION < (1, 9):  # pragma: no cover
@@ -114,8 +119,11 @@ def read_frame(qs, fieldnames=(), index_col=None, coerce_float=False,
     else:
         recs = list(qs.values_list(*fieldnames))
 
-    df = pd.DataFrame.from_records(recs, columns=fieldnames,
-                                   coerce_float=coerce_float)
+    df = pd.DataFrame.from_records(
+        recs,
+        columns=column_names if column_names else fieldnames,
+        coerce_float=coerce_float
+    )
 
     if verbose:
         update_with_verbose(df, fieldnames, fields)

--- a/django_pandas/tests/test_io.py
+++ b/django_pandas/tests/test_io.py
@@ -57,6 +57,16 @@ class IOTest(TestCase):
                          ['index_col', 'col1', 'scol1', 'ecol1'])
         self.assertEqual(list(df["col1"]), list(df["scol1"]))
 
+    def test_override_column_names(self):
+        qs = MyModel.objects.all()
+        df = read_frame(
+            qs,
+            index_col='id',
+            fieldnames=['col1', 'col2', 'col3', 'col4'],
+            column_names=['a', 'b', 'c', 'd']
+        )
+        self.assertEqual(list(df.columns), ['a', 'b', 'c', 'd'])
+
     def test_duplicate_annotation(self):
         qs = MyModel.objects.all()
         qs = qs.values('index_col')


### PR DESCRIPTION
This is convenient when you need a more descriptive name in the DataFrame columns from what the model field names provide. 