### PR TITLE
Fix for now removed how kwarg to df.resample.

### DIFF
--- a/django_pandas/managers.py
+++ b/django_pandas/managers.py
@@ -135,7 +135,8 @@ class DataFrameQuerySet(QuerySet):
     def to_timeseries(self, fieldnames=(), verbose=True,
                       index=None, storage='wide',
                       values=None, pivot_columns=None, freq=None,
-                      coerce_float=True, rs_kwargs=None):
+                      coerce_float=True, rs_kwargs=None, agg_args=None,
+                      agg_kwargs=None):
         """
         A convenience method for creating a time series DataFrame i.e the
         DataFrame index will be an instance of  DateTime or PeriodIndex
@@ -195,6 +196,12 @@ class DataFrameQuerySet(QuerySet):
         rs_kwargs:  A dictonary of keyword arguments based on the
                     ``pandas.DataFrame.resample`` method
 
+        agg_kwargs:  A dictonary of keyword arguments to send to the
+                    ``pandas.DataFrame.resample().agg()`` method
+
+        agg_args:  A list of positional arguments to send to the
+                    ``pandas.DataFrame.resample().agg()`` method
+
         verbose:  If  this is ``True`` then populate the DataFrame with the
                   human readable versions of any foreign key fields else use
                   the primary keys values else use the actual values set
@@ -233,7 +240,11 @@ class DataFrameQuerySet(QuerySet):
                               values=values)
 
         if freq is not None:
-            df = df.resample(freq, **rs_kwargs)
+            if agg_kwargs is None:
+                agg_kwargs=dict(func='mean')
+            if agg_args is None:
+                agg_args=[]
+            df = df.resample(freq, **rs_kwargs).agg(*agg_args, **agg_kwargs)
 
         return df
 

--- a/django_pandas/managers.py
+++ b/django_pandas/managers.py
@@ -241,7 +241,7 @@ class DataFrameQuerySet(QuerySet):
 
         if freq is not None:
             if agg_kwargs is None:
-                agg_kwargs=dict(func='mean')
+                agg_kwargs=dict()
             if agg_args is None:
                 agg_args=[]
             df = df.resample(freq, **rs_kwargs).agg(*agg_args, **agg_kwargs)

--- a/django_pandas/tests/test_manager.py
+++ b/django_pandas/tests/test_manager.py
@@ -119,10 +119,12 @@ class TimeSeriesTest(TestCase):
 
     def test_resampling(self):
         qs = LongTimeSeries.objects.all()
-        rs_kwargs = {'how': 'sum', 'kind': 'period'}
+        rs_kwargs = {'kind': 'period'}
+        agg_kwargs = {'func': 'sum'}
         df = qs.to_timeseries(index='date_ix', pivot_columns='series_name',
                               values='value', storage='long',
-                              freq='M', rs_kwargs=rs_kwargs)
+                              freq='M', rs_kwargs=rs_kwargs,
+                              agg_kwargs=agg_kwargs)
 
         self.assertEqual([d.month for d in qs.dates('date_ix', 'month')],
                          df.index.month.tolist())

--- a/django_pandas/tests/test_manager.py
+++ b/django_pandas/tests/test_manager.py
@@ -8,7 +8,9 @@ from .models import (
     LongTimeSeries, PivotData, Dude, Car, Spot
 )
 import pandas.util.testing as tm
+import semver
 
+PANDAS_VERSIONINFO = semver.VersionInfo.parse(pd.__version__)
 
 class DataFrameTest(TestCase):
 
@@ -120,10 +122,16 @@ class TimeSeriesTest(TestCase):
     def test_resampling(self):
         qs = LongTimeSeries.objects.all()
         rs_kwargs = {'kind': 'period'}
-        agg_kwargs = {'func': 'sum'}
+        agg_args = None
+        agg_kwargs = None
+        if PANDAS_VERSIONINFO >= '0.25.0':
+            agg_kwargs = {'func': 'sum'}
+        else:
+            agg_args= ['sum']
         df = qs.to_timeseries(index='date_ix', pivot_columns='series_name',
                               values='value', storage='long',
                               freq='M', rs_kwargs=rs_kwargs,
+                              agg_args=agg_args,
                               agg_kwargs=agg_kwargs)
 
         self.assertEqual([d.month for d in qs.dates('date_ix', 'month')],
@@ -135,7 +143,9 @@ class TimeSeriesTest(TestCase):
         qs2 = WideTimeSeries.objects.all()
 
         df1 = qs2.to_timeseries(index='date_ix', storage='wide',
-                                freq='M', rs_kwargs=rs_kwargs)
+                                freq='M', rs_kwargs=rs_kwargs,
+                                agg_args=agg_args,
+                                agg_kwargs = agg_kwargs)
 
         self.assertEqual([d.month for d in qs.dates('date_ix', 'month')],
                          df1.index.month.tolist())

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     tests_require=[
         "pandas>=0.20.1",
         "coverage>=4.0",
+        "semver==2.10.1"
                    ],
     test_suite="runtests.runtests"
 


### PR DESCRIPTION
Support agg() instead, and allow agg_args and agg_kwargs to be passed to
to_timeseries().

This should fix incompatibility with the latest pandas releases. See #118 