### PR TITLE
Cast pk to int for cache key

### DIFF
--- a/django_pandas/utils.py
+++ b/django_pandas/utils.py
@@ -39,7 +39,7 @@ def replace_pk(model):
     base_cache_key = get_base_cache_key(model)
 
     def get_cache_key_from_pk(pk):
-        return None if pk is None else base_cache_key % pk
+        return None if pk is None else base_cache_key % int(pk)
 
     def inner(pk_series):
         pk_series = pk_series.where(pk_series.notnull(), None)


### PR DESCRIPTION
I'm working in a project where the foreign key is nullable. When pandas initially imports the foreign key, the type is cast to float so the null fields can be represented as NaN. The float fields are then formatted as "4.0" and "5.0" in the cache key which cause cache misses later when the other pk's are formatted as "4" and "5" respectively.

The cast to integer here is heavy-handed but I'm not sure a better way.