### PR TITLE
Support Django > 3

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,3 +27,4 @@ Contributions
 - `Anthony Monthe <https://github.com/ZuluPro>`_
 - `Vincent Toupet <https://github.com/vtoupet>`_
 - `Anton Ian Sipos <https://github.com/aisipos>`_
+- `Chuan-Jhe Hwong <https://github.com/CJHwong>`_

--- a/django_pandas/io.py
+++ b/django_pandas/io.py
@@ -3,13 +3,20 @@ from .utils import update_with_verbose, get_related_model
 import django
 
 
+FieldDoesNotExist = (
+    django.db.models.fields.FieldDoesNotExist
+    if django.VERSION < (1, 8)
+    else django.core.exceptions.FieldDoesNotExist
+)
+
+
 def to_fields(qs, fieldnames):
     for fieldname in fieldnames:
         model = qs.model
         for fieldname_part in fieldname.split('__'):
             try:
                 field = model._meta.get_field(fieldname_part)
-            except django.db.models.fields.FieldDoesNotExist:
+            except FieldDoesNotExist:
                 try:
                     rels = model._meta.get_all_related_objects_with_model()
                 except AttributeError:

--- a/django_pandas/tests/models.py
+++ b/django_pandas/tests/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django_pandas.managers import DataFrameManager, PassThroughManager
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'pandas>=0.14.1',
+        'six>=1.15.0',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
1. Django builtin six library was removed since v3.0.0
2. FieldDoesNotExist was moved to django.core.exceptions since v1.8.0, and its comp module was removed since v3.1.0