### PR TITLE
Fall back to old behavior when PKs are not coercible to int

### DIFF
--- a/django_pandas/utils.py
+++ b/django_pandas/utils.py
@@ -39,7 +39,10 @@ def replace_pk(model):
     base_cache_key = get_base_cache_key(model)
 
     def get_cache_key_from_pk(pk):
-        return None if pk is None else base_cache_key % int(pk)
+        try:
+            return None if pk is None else base_cache_key % int(pk)
+        except ValueError:
+            return None if pk is None else base_cache_key % pk
 
     def inner(pk_series):
         pk_series = pk_series.where(pk_series.notnull(), None)


### PR DESCRIPTION
I'm not sure if this is a great fix, but the old behavior didn't cause any issues for me. 0.6.4 broke on a model with a varchar/string primary key and this seems to fix it.